### PR TITLE
DP-7569: Port button component.

### DIFF
--- a/src/components/atoms/Button.js
+++ b/src/components/atoms/Button.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Button = ({children, className, onClick}) => {
+  const buttonClass = className || "ma__button";
+  return (
+    <button type="button" className={buttonClass} aria-label="" onClick={onClick}>{children}</button>
+  );
+};
+
+export default Button;

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@
 export SocialIcon from './components/SocialIcon';
 
 // @atoms
+export Button from './components/atoms/Button';
 
 // @molecules
 export FooterLinks from './components/molecules/FooterLinks';

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -12,7 +12,7 @@ import Button from '../src/components/atoms/Button';
 import Footer from '../src/components/organisms/Footer';
 
 storiesOf('Welcome', module).add('to Storybook', () => <Welcome showApp={linkTo('Button')} />);
-storiesOf('Button', module)
+storiesOf('Atoms', module)
   .add('Button', () => <Button>Submit</Button>);
-storiesOf('Footer', module)
+storiesOf('Organisms', module)
   .add('Footer', () => <Footer />);

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -8,9 +8,11 @@ import '@massds/mayflower/css/index-generated.css';
 import '@massds/mayflower/css/base-theme-generated.css';
 
 import { Welcome } from '@storybook/react/demo';
+import Button from '../src/components/atoms/Button';
 import Footer from '../src/components/organisms/Footer';
 
 storiesOf('Welcome', module).add('to Storybook', () => <Welcome showApp={linkTo('Button')} />);
-
+storiesOf('Button', module)
+  .add('Button', () => <Button>Submit</Button>);
 storiesOf('Footer', module)
   .add('Footer', () => <Footer />);


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:** 
This adds the button atom to the component list. This also modifies the storybook to display an example button.

**Jira:** 
https://jira.state.ma.us/browse/DP-7569

**To Test:**
- [ ] Pull the branch and run 'npm run storybook'.
- [ ] Browse to http://localhost:6006/ (or the port that you chose instead) and verify there's now an Atoms link on the left side. Click on it and click on 'Button'. Verify that a button is rendered the same as the attached screenshot.

**Post Deploy Steps:**
N/A

**Relevant Screenshots/GIFs:**
<img width="559" alt="screen shot 2018-01-24 at 4 18 18 pm" src="https://user-images.githubusercontent.com/5257660/35357696-540e2fde-0122-11e8-8975-8cea8667fbac.png">

**Additional Notes:**
N/A
---

[Peer Review Checklist](docs/Peer%20review%20checklist.md)
