### PR TITLE
Dp 7717 callout link molecule mayflower react

### DIFF
--- a/src/components/molecules/CalloutLink/CalloutLink.md
+++ b/src/components/molecules/CalloutLink/CalloutLink.md
@@ -1,5 +1,13 @@
-This is the standard callout link pattern
+This pattern shows a link styled as a card
 
 ##### Mayflower Pattern
 
-[@molecules/callout-link](https://mayflower.digital.mass.gov/?p=molecules-callout-link&view=c)
+* [@molecules/callout-link](https://mayflower.digital.mass.gov/?p=molecules-callout-link&view=c)
+* [@molecules/callout-link-as-description](https://mayflower.digital.mass.gov/?p=molecules-callout-link-as-description)
+
+##### Pattern Contains
+* SVG Arrow atom
+
+
+
+

--- a/src/components/molecules/CalloutLink/CalloutLink.md
+++ b/src/components/molecules/CalloutLink/CalloutLink.md
@@ -1,0 +1,5 @@
+This is the standard callout link pattern
+
+##### Mayflower Pattern
+
+[@molecules/callout-link](https://mayflower.digital.mass.gov/?p=molecules-callout-link&view=c)

--- a/src/components/molecules/CalloutLink/CalloutLink.stories.js
+++ b/src/components/molecules/CalloutLink/CalloutLink.stories.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { withKnobs, text, boolean, select } from '@storybook/addon-knobs/react';
+
+import CalloutLink from './index';
+import CalloutLinkDocs from './CalloutLink.md';
+
+storiesOf('molecules', module).addDecorator(withKnobs)
+  .add('CalloutLink', withInfo(CalloutLinkDocs)(() => {
+    const props = {
+      text: text('calloutLink.text', 'Link to another page'),
+      href: text('calloutLink.href', ''),
+      info: text('calloutLink.info', 'this will be the tooltip text on hover')
+    };
+    return(
+      <CalloutLink {...props} />
+    );
+  }));

--- a/src/components/molecules/CalloutLink/CalloutLink.stories.js
+++ b/src/components/molecules/CalloutLink/CalloutLink.stories.js
@@ -8,7 +8,7 @@ import CalloutLink from './index';
 import CalloutLinkDocs from './CalloutLink.md';
 
 storiesOf('molecules', module).addDecorator(withKnobs)
-  .add('CalloutLink', withInfo(`<div>`+CalloutLinkDocs+`</div>`)(() => {
+  .add('CalloutLink', withInfo(`<div>${CalloutLinkDocs}</div>`)(() => {
     const props = {
       text: text('calloutLink.text', 'Link to another page'),
       href: text('calloutLink.href', ''),

--- a/src/components/molecules/CalloutLink/CalloutLink.stories.js
+++ b/src/components/molecules/CalloutLink/CalloutLink.stories.js
@@ -8,7 +8,7 @@ import CalloutLink from './index';
 import CalloutLinkDocs from './CalloutLink.md';
 
 storiesOf('molecules', module).addDecorator(withKnobs)
-  .add('CalloutLink', withInfo(CalloutLinkDocs)(() => {
+  .add('CalloutLink', withInfo(`<div>`+CalloutLinkDocs+`</div>`)(() => {
     const props = {
       text: text('calloutLink.text', 'Link to another page'),
       href: text('calloutLink.href', ''),

--- a/src/components/molecules/CalloutLink/CalloutLink.stories.js
+++ b/src/components/molecules/CalloutLink/CalloutLink.stories.js
@@ -12,7 +12,8 @@ storiesOf('molecules', module).addDecorator(withKnobs)
     const props = {
       text: text('calloutLink.text', 'Link to another page'),
       href: text('calloutLink.href', ''),
-      info: text('calloutLink.info', 'this will be the tooltip text on hover')
+      info: text('calloutLink.info', 'this will be the tooltip text on hover'),
+      description: text('calloutLink.description', '')
     };
     return(
       <CalloutLink {...props} />

--- a/src/components/molecules/CalloutLink/index.js
+++ b/src/components/molecules/CalloutLink/index.js
@@ -25,9 +25,4 @@ CalloutLink.propTypes = {
   description: PropTypes.string
 };
 
-CalloutLink.defaultProps = {
-  info: '',
-  description: ''
-};
-
 export default CalloutLink;

--- a/src/components/molecules/CalloutLink/index.js
+++ b/src/components/molecules/CalloutLink/index.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import SvgArrow from '../../atoms/icons/SvgArrow';
+
+const CalloutLink = (props) => {
+  const calloutLink = props;
+
+  return(
+    <div className="ma__callout-link" title={calloutLink.info}>
+      <a href={calloutLink.href}><span className="ma__callout-link__container"><span className="ma__callout-link__text" >{calloutLink.text}&nbsp;<SvgArrow /></span></span></a>
+    </div>
+  );
+};
+
+CalloutLink.propTypes = {
+  /** The heading text  */
+  text: PropTypes.string.isRequired,
+  /** The link the callout is going to */
+  href: PropTypes.string.isRequired,
+  /** Add more information about the link */
+  info: PropTypes.string
+};
+
+CalloutLink.defaultProps = {
+  info: ''
+};
+
+export default CalloutLink;

--- a/src/components/molecules/CalloutLink/index.js
+++ b/src/components/molecules/CalloutLink/index.js
@@ -4,7 +4,7 @@ import SvgArrow from '../../atoms/icons/SvgArrow';
 
 const CalloutLink = (props) => {
   const calloutLink = props;
-  ;
+
 
   return(
     <div className="ma__callout-link" title={calloutLink.info}>

--- a/src/components/molecules/CalloutLink/index.js
+++ b/src/components/molecules/CalloutLink/index.js
@@ -4,10 +4,12 @@ import SvgArrow from '../../atoms/icons/SvgArrow';
 
 const CalloutLink = (props) => {
   const calloutLink = props;
+  ;
 
   return(
     <div className="ma__callout-link" title={calloutLink.info}>
       <a href={calloutLink.href}><span className="ma__callout-link__container"><span className="ma__callout-link__text" >{calloutLink.text}&nbsp;<SvgArrow /></span></span></a>
+      { calloutLink.description ? <p className="ma__callout-link__description">{calloutLink.description}</p> : '' }
     </div>
   );
 };
@@ -18,11 +20,14 @@ CalloutLink.propTypes = {
   /** The link the callout is going to */
   href: PropTypes.string.isRequired,
   /** Add more information about the link */
-  info: PropTypes.string
+  info: PropTypes.string,
+  /** Add description text under the title text */
+  description: PropTypes.string
 };
 
 CalloutLink.defaultProps = {
-  info: ''
+  info: '',
+  description: ''
 };
 
 export default CalloutLink;

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,5 @@ export { OrgSelector } from './components/molecules/OrgSelector';
 export { SocialLinks } from './components/molecules/SocialLinks';
 
 // @organisms
-export { Footer } from './components/organisms/footer';
 export { Footer } from './components/organisms/Footer';
 export { PressFilters } from './components/organisms/PressFilters';

--- a/src/index.js
+++ b/src/index.js
@@ -28,4 +28,4 @@ export { SocialLinks } from './components/molecules/SocialLinks';
 export { DateRange } from './components/molecules/DateRange';
 
 // @organisms
-export { Footer } from './components/organisms/Footer';
+export { Footer } from './components/organisms/footer';


### PR DESCRIPTION
**Description**
Adds the CalloutLink molecule as a component in Mayflower React. 

**JIRA**
https://jira.state.ma.us/browse/DP-7717

**To Test**
- [ ] Pull the branch down and run `npm start`
- [ ] Navigate to http://localhost:6006/ and confirm that the molecules > CalloutLink component exists and matches the functionality and appearance of [Mayflower](https://mayflower.digital.mass.gov/?p=molecules-callout-link)
- [ ] Adjust the "Knobs" settings below and confirm that they modify the heading as expected.

**button-golden branch pr needs to be merged before this**

**Screenshot**
<img width="500" alt="screen shot 2018-02-01 at 5 01 14 pm" src="https://user-images.githubusercontent.com/9359261/35705948-ff3438b8-0771-11e8-919e-84dc27412875.png">
<img width="500" alt="screen shot 2018-02-01 at 5 01 30 pm" src="https://user-images.githubusercontent.com/9359261/35705962-0d1ebe12-0772-11e8-9eaa-2884457c6ce7.png">

**Note**
I have added the description variable to this component, which is required for promoted results. For that variable to be used and displayed as expected in the design, we are dependent on the merger of this [PR](https://github.com/massgov/mayflower/pull/684) in to Mayflower twig.